### PR TITLE
Fix dict equals and test

### DIFF
--- a/integration_tests/macros/tests/test_assert_dict_equals.sql
+++ b/integration_tests/macros/tests/test_assert_dict_equals.sql
@@ -6,5 +6,12 @@
      "k4": True,
      "k5": False,
     } %}
-  {{ dbt_unittest.assert_equals({"k1": 1, "k2": "2", "k3": none}, {"k1": 1, "k2": "2", "k3": none}) }}
+  {% set y = {
+     "k1": 1,
+     "k2": "2",
+     "k3": none,
+     "k4": True,
+     "k5": False,
+    } %}
+  {{ dbt_unittest.assert_dict_equals(x, y) }}
 {% endmacro %}

--- a/macros/assert_dict_equals.sql
+++ b/macros/assert_dict_equals.sql
@@ -21,15 +21,15 @@
   {% endfor %}
 
   {% for k, v in expected.items() %}
-    {% if k not in values %}
-      {% do exceptions.raise_compiler_error("FAILED: key " ~ k ~ " of 1st argument is not in " ~ values ~ ".") %}
+    {% if k not in value %}
+      {% do exceptions.raise_compiler_error("FAILED: key " ~ k ~ " of 2nd argument is not in " ~ value ~ ".") %}
     {% endif %}
 
-    {% if v is none and values[k] is not none %}
+    {% if v is none and value[k] is not none %}
       {% do exceptions.raise_compiler_error("FAILED: values on the key " ~ k ~ " are not same.") %}
     {% endif %}
 
-    {% if v != values[k] %}
+    {% if v != value[k] %}
       {% do exceptions.raise_compiler_error("FAILED: values on the key " ~ k ~ " are not same.") %}
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
Current the dict equals macro does not work, even the dummy example on the readme fails due to a typo in the object call in the fuction - this isn't caught by the tests and the test currently tests a differnet macro.

This PR corrects this, provides a more correct failure message, and updates the tests to test the correct macro.

It would be useful as well if there was a way to test for a failure when it is expected, but I wasn't sure if there is an equivalent  to `with pytest.raises(...` in dbt/jinja.