### PR TITLE
Allow test success messages to be written to stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a dbt package to enhance dbt package development by providing unit testi
   * [`assert_not_in`](#assert_not_in)
   * [`assert_list_equals`](#assert_list_equals)
   * [`assert_dict_equals`](#assert_dict_equals)
+- [Log messages](#log-messages)
 
 <!-- tocstop -->
 
@@ -109,6 +110,12 @@ Test that two dictionaries are equal.
 **Usage:**
 ```sql
   {{ dbt_unittest.assert_dict_equals({"k": 1}, {"k": 1}) }}
+```
+
+## Log messages
+Test failures are written to dbt's log file and to stdout. Test passes are written only to dbt's log file by default. To write test passes to stdout as well, pass `true` to the `stdout` parameter in the macro calls:
+```sql
+{{ dbt_unittest.assert_equals("foo", "foo", stdout=true)}}
 ```
 
 ## Contributors

--- a/macros/assert_dict_equals.sql
+++ b/macros/assert_dict_equals.sql
@@ -1,4 +1,4 @@
-{% macro assert_dict_equals(value, expected) %}
+{% macro assert_dict_equals(value, expected, stdout=false) %}
   {% if value is not mapping %}
     {% do exceptions.raise_compiler_error("FAILED: 1st argument " ~ value ~ " is not a mapping.") %}
   {% endif %}
@@ -34,5 +34,5 @@
     {% endif %}
   {% endfor %}
 
-  {% do log("SUCCESS") %}
+  {% do log("SUCCESS", info=stdout) %}
 {% endmacro %}

--- a/macros/assert_equals.sql
+++ b/macros/assert_equals.sql
@@ -1,6 +1,6 @@
-{% macro assert_equals(value, expected) %}
+{% macro assert_equals(value, expected, stdout=false) %}
   {% if value == expected %}
-    {% do log("SUCCESS") %}
+    {% do log("SUCCESS", info=stdout) %}
   {% else %}
     {% do exceptions.raise_compiler_error("FAILED: " ~ value ~ " is not equal to " ~ expected ~ ".") %}
   {% endif %}

--- a/macros/assert_false.sql
+++ b/macros/assert_false.sql
@@ -1,10 +1,10 @@
-{% macro assert_false(value) %}
+{% macro assert_false(value, stdout=false) %}
   {% if value is not boolean %}
     {% do exceptions.raise_compiler_error("FAILED: " ~ value ~ " is not boolean.") %}
   {% endif %}
 
   {% if value is false %}
-    {% do log("SUCCESS") %}
+    {% do log("SUCCESS", info=stdout) %}
   {% else %}
     {% do exceptions.raise_compiler_error("FAILED: value " ~ value ~ " is not false.") %}
   {% endif %}

--- a/macros/assert_in.sql
+++ b/macros/assert_in.sql
@@ -1,6 +1,6 @@
-{% macro assert_in(value, expected) %}
+{% macro assert_in(value, expected, stdout=false) %}
   {% if value in expected %}
-    {% do log("SUCCESS") %}
+    {% do log("SUCCESS", info=stdout) %}
   {% else %}
     {% do exceptions.raise_compiler_error("FAILED: value " ~ value ~ " is not in " ~ expected ~ ".") %}
   {% endif %}

--- a/macros/assert_is_none.sql
+++ b/macros/assert_is_none.sql
@@ -1,6 +1,6 @@
-{% macro assert_is_none(value) %}
+{% macro assert_is_none(value, stdout=false) %}
   {% if value is none %}
-    {% do log("SUCCESS") %}
+    {% do log("SUCCESS", info=stdout) %}
   {% else %}
     {% do exceptions.raise_compiler_error("FAILED: value " ~ value ~ " is not none.") %}
   {% endif %}

--- a/macros/assert_is_not_none.sql
+++ b/macros/assert_is_not_none.sql
@@ -1,6 +1,6 @@
-{% macro assert_is_not_none(value) %}
+{% macro assert_is_not_none(value, stdout=false) %}
   {% if value is not none %}
-    {% do log("SUCCESS") %}
+    {% do log("SUCCESS", info=stdout) %}
   {% else %}
     {% do exceptions.raise_compiler_error("FAILED: value " ~ value ~ " is none.") %}
   {% endif %}

--- a/macros/assert_list_equals.sql
+++ b/macros/assert_list_equals.sql
@@ -1,4 +1,4 @@
-{% macro assert_list_equals(value, expected) %}
+{% macro assert_list_equals(value, expected, stdout=false) %}
   {% if value is not iterable %}
     {% do exceptions.raise_compiler_error("FAILED: 1st argument " ~ value ~ " is not iterable.") %}
   {% endif %}
@@ -19,5 +19,5 @@
     {% endif %}
   {% endfor %}
 
-  {% do log("SUCCESS") %}
+  {% do log("SUCCESS", info=stdout) %}
 {% endmacro %}

--- a/macros/assert_not_equals.sql
+++ b/macros/assert_not_equals.sql
@@ -1,4 +1,4 @@
-{% macro assert_not_equals(value, expected) %}
+{% macro assert_not_equals(value, expected, stdout=false) %}
   {% if value != expected %}
     {% do log("SUCCESS") %}
   {% else %}

--- a/macros/assert_not_in.sql
+++ b/macros/assert_not_in.sql
@@ -1,4 +1,4 @@
-{% macro assert_not_in(value, expected) %}
+{% macro assert_not_in(value, expected, stdout=false) %}
   {% if value not in expected %}
     {% do log("SUCCESS") %}
   {% else %}

--- a/macros/assert_true.sql
+++ b/macros/assert_true.sql
@@ -1,4 +1,4 @@
-{% macro assert_true(value) %}
+{% macro assert_true(value, stdout=false) %}
   {% if value is not boolean %}
     {% do exceptions.raise_compiler_error("FAILED: " ~ value ~ " is not boolean.") %}
   {% endif %}


### PR DESCRIPTION
Closes #18

Macros updated with new parameter, with a default value of `false` to preserve behaviour of existing implementations.