### PR TITLE
Add list comparison macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ This is a dbt package to enhance dbt package development by providing unit testi
   * [`assert_not_in`](#assert_not_in)
   * [`assert_list_equals`](#assert_list_equals)
   * [`assert_dict_equals`](#assert_dict_equals)
+  * [Comparison macros](#comparison-macros)
+    * [`equals`](#equals)
+    * [`not_equals`](#not_equals)
+    * [`contains`](#contains)
+    * [`not_in`](#not_in)
+    * [`is_true`](#is_true)
+    * [`is_false`](#is_false)
+    * [`is_none`](#is_none)
+    * [`is_not_none`](#is_not_none)
+    * [`list_equals`](#list_equals)
+    * [`dict_equals`](#dict_equals)
 
 <!-- tocstop -->
 
@@ -109,6 +120,88 @@ Test that two dictionaries are equal.
 **Usage:**
 ```sql
   {{ dbt_unittest.assert_dict_equals({"k": 1}, {"k": 1}) }}
+```
+
+## Comparison macros
+
+### `equals`
+Return true if two values are equal.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.equals(1, 1) %}
+```
+
+### `not_equals`
+Return true if two values are not equal.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.not_equals(1, 2) %}
+```
+
+### `contains`
+Return true if a value exists within a collection.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.contains(1, [1, 2, 3]) %}
+```
+
+### `not_in`
+Return true if a value does not exist within a collection.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.not_in(4, [1, 2, 3]) %}
+```
+
+### `is_true`
+Return true when the value is strictly `true`.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.is_true(true) %}
+```
+
+### `is_false`
+Return true when the value is strictly `false`.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.is_false(false) %}
+```
+
+### `is_none`
+Return true if the value is `None`.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.is_none(none) %}
+```
+
+### `is_not_none`
+Return true if the value is not `None`.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.is_not_none(1) %}
+```
+
+### `list_equals`
+Return true if two lists are equal. Lists may contain nested lists or dictionaries.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.list_equals([1, 2], [1, 2]) %}
+```
+
+### `dict_equals`
+Return true if two dictionaries are equal. Dictionaries may contain nested dictionaries or lists.
+
+**Usage:**
+```sql
+  {% set result = dbt_unittest.dict_equals({'a': 1}, {'a': 1}) %}
 ```
 
 ## Contributors

--- a/integration_tests/macros/tests/comparisons/test_contains.sql
+++ b/integration_tests/macros/tests/comparisons/test_contains.sql
@@ -1,24 +1,24 @@
-{% macro test_in() %}
+{% macro test_contains() %}
   {# Test successful in condition with list #}
-  {% set result1 = dbt_unittest.in(5, [1, 2, 3, 4, 5]) %}
+  {% set result1 = dbt_unittest.contains(5, [1, 2, 3, 4, 5]) %}
   {% if not result1 %}
     {{ exceptions.raise_compiler_error("Failed: 5 should be in [1, 2, 3, 4, 5]") }}
   {% endif %}
 
   {# Test failed in condition with list #}
-  {% set result2 = dbt_unittest.in(6, [1, 2, 3, 4, 5]) %}
+  {% set result2 = dbt_unittest.contains(6, [1, 2, 3, 4, 5]) %}
   {% if result2 %}
     {{ exceptions.raise_compiler_error("Failed: 6 should not be in [1, 2, 3, 4, 5]") }}
   {% endif %}
 
   {# Test successful in condition with string #}
-  {% set result3 = dbt_unittest.in('a', 'abcde') %}
+  {% set result3 = dbt_unittest.contains('a', 'abcde') %}
   {% if not result3 %}
     {{ exceptions.raise_compiler_error("Failed: 'a' should be in 'abcde'") }}
   {% endif %}
 
   {# Test failed in condition with string #}
-  {% set result4 = dbt_unittest.in('f', 'abcde') %}
+  {% set result4 = dbt_unittest.contains('f', 'abcde') %}
   {% if result4 %}
     {{ exceptions.raise_compiler_error("Failed: 'f' should not be in 'abcde'") }}
   {% endif %}

--- a/integration_tests/macros/tests/comparisons/test_list_equals.sql
+++ b/integration_tests/macros/tests/comparisons/test_list_equals.sql
@@ -1,0 +1,46 @@
+{% macro test_list_equals() %}
+  {# Identical lists #}
+  {% set list1 = [1, 2, 3] %}
+  {% set list2 = [1, 2, 3] %}
+  {% set result1 = dbt_unittest.list_equals(list1, list2) %}
+  {% if not result1 %}
+    {{ exceptions.raise_compiler_error("Failed: identical lists should be equal") }}
+  {% endif %}
+
+  {# Different lists #}
+  {% set list3 = [1, 2, 4] %}
+  {% set result2 = dbt_unittest.list_equals(list1, list3) %}
+  {% if result2 %}
+    {{ exceptions.raise_compiler_error("Failed: different lists should not be equal") }}
+  {% endif %}
+
+  {# Empty lists #}
+  {% set list4 = [] %}
+  {% set list5 = [] %}
+  {% set result3 = dbt_unittest.list_equals(list4, list5) %}
+  {% if not result3 %}
+    {{ exceptions.raise_compiler_error("Failed: empty lists should be equal") }}
+  {% endif %}
+
+  {# Lists of dictionaries #}
+  {% set list6 = [{'a': 1}, {'b': 2}] %}
+  {% set list7 = [{'a': 1}, {'b': 2}] %}
+  {% set result4 = dbt_unittest.list_equals(list6, list7) %}
+  {% if not result4 %}
+    {{ exceptions.raise_compiler_error("Failed: list of dicts should be equal") }}
+  {% endif %}
+
+  {% set list8 = [{'a': 1}, {'b': 3}] %}
+  {% set result5 = dbt_unittest.list_equals(list6, list8) %}
+  {% if result5 %}
+    {{ exceptions.raise_compiler_error("Failed: list of dicts with different values should not be equal") }}
+  {% endif %}
+
+  {# Nested lists #}
+  {% set list9 = [[1, 2], [3, 4]] %}
+  {% set list10 = [[1, 2], [3, 4]] %}
+  {% set result6 = dbt_unittest.list_equals(list9, list10) %}
+  {% if not result6 %}
+    {{ exceptions.raise_compiler_error("Failed: nested lists should be equal") }}
+  {% endif %}
+{% endmacro %}

--- a/integration_tests/macros/tests/test_assert_list_equals.sql
+++ b/integration_tests/macros/tests/test_assert_list_equals.sql
@@ -1,5 +1,5 @@
 {% macro test_assert_list_equals() %}
-  {{ dbt_unittest.assert_equals([], []) }}
-  {{ dbt_unittest.assert_equals([1, 2], [1, 2]) }}
-  {{ dbt_unittest.assert_equals(["1", "2"], ["1", "2"]) }}
+  {{ dbt_unittest.assert_list_equals([], []) }}
+  {{ dbt_unittest.assert_list_equals([1, 2], [1, 2]) }}
+  {{ dbt_unittest.assert_list_equals(["1", "2"], ["1", "2"]) }}
 {% endmacro %}

--- a/integration_tests/macros/tests/test_macros.sql
+++ b/integration_tests/macros/tests/test_macros.sql
@@ -15,7 +15,8 @@
   {% do test_not_equals() %}
   {% do test_is_true() %}
   {% do test_is_false() %}
-  {% do test_in() %}
+  {% do test_contains() %}
   {% do test_not_in() %}
   {% do test_dict_equals() %}
+  {% do test_list_equals() %}
 {% endmacro %}

--- a/macros/assert_in.sql
+++ b/macros/assert_in.sql
@@ -1,5 +1,5 @@
 {% macro assert_in(value, expected) %}
-  {% if not dbt_unittest.in(value, expected) %}
+  {% if not dbt_unittest.contains(value, expected) %}
     {% do exceptions.raise_compiler_error("FAILED: " ~ value ~ " is not in " ~ expected ~ ".") %}
   {% endif %}
 {% endmacro %}

--- a/macros/comparisons/contains.sql
+++ b/macros/comparisons/contains.sql
@@ -1,4 +1,4 @@
-{% macro in(value, expected) %}
+{% macro contains(value, expected) %}
   {% set is_in = false %}
 
   {# Handle different types of collections #}

--- a/macros/comparisons/list_equals.sql
+++ b/macros/comparisons/list_equals.sql
@@ -1,4 +1,4 @@
-{% macro dict_equals(actual, expected) %}
+{% macro list_equals(actual, expected) %}
   {# Handle None cases #}
   {% if actual is none and expected is none %}
     {{ return(true) }}
@@ -9,30 +9,23 @@
     {{ return(false) }}
   {% endif %}
 
-  {# Check for mapping types #}
-  {% if actual is not mapping or expected is not mapping %}
+  {# Ensure both arguments are iterables and not strings #}
+  {% if actual is not iterable or expected is not iterable %}
+    {{ return(false) }}
+  {% endif %}
+  {% if actual is string or expected is string %}
     {{ return(false) }}
   {% endif %}
 
-  {# Check key lengths #}
-  {% set actual_keys = actual.keys() | list | sort %}
-  {% set expected_keys = expected.keys() | list | sort %}
-  {% if actual_keys | length != expected_keys | length %}
+  {# Check length #}
+  {% if actual | length != expected | length %}
     {{ return(false) }}
   {% endif %}
 
-  {# Check keys exist and match #}
-  {% for key in actual_keys %}
-    {% if key not in expected_keys %}
-      {{ return(false) }}
-    {% endif %}
-  {% endfor %}
-
-  {# Check values, recursively for nested dicts #}
-  {% for key in actual_keys %}
-    {% set a = actual[key] %}
-    {% set b = expected[key] %}
-
+  {# Compare each element, recursively handling lists and dicts #}
+  {% for i in range(actual | length) %}
+    {% set a = actual[i] %}
+    {% set b = expected[i] %}
     {% if a is mapping and b is mapping %}
       {% if not dbt_unittest.dict_equals(a, b) %}
         {{ return(false) }}
@@ -46,6 +39,5 @@
     {% endif %}
   {% endfor %}
 
-  {# If we've made it this far, dictionaries are equal #}
   {{ return(true) }}
 {% endmacro %}


### PR DESCRIPTION
## Summary
- add a `list_equals` macro for boolean comparison
- use `assert_list_equals` in tests
- add unit tests for `list_equals`
- update dict comparison to use `list_equals`
- document comparison macros in README
- rename `in` comparison macro to `contains` to avoid reserved keyword

## Testing
- `integration_tests/run_unit_tests.sh` *(fails: `dbt: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684253748048832c9115cefaec7cb49d