### PR TITLE
Update dbt matrix

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,34 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - pip-requirements: requirements-1.0.txt
-            python-version: "3.9"
-          - pip-requirements: requirements-1.1.txt
-            python-version: "3.9"
-          - pip-requirements: requirements-1.2.txt
-            python-version: "3.9"
-          - pip-requirements: requirements-1.2.txt
-            python-version: "3.10"
-          - pip-requirements: requirements-1.3.txt
-            python-version: "3.9"
-          - pip-requirements: requirements-1.3.txt
-            python-version: "3.10"
-          - pip-requirements: requirements-1.4.txt
-            python-version: "3.9"
-          - pip-requirements: requirements-1.4.txt
-            python-version: "3.10"
-          - pip-requirements: requirements-1.5.txt
-            python-version: "3.9"
-          - pip-requirements: requirements-1.5.txt
-            python-version: "3.10"
-          - pip-requirements: requirements-1.5.txt
-            python-version: "3.11"
-          - pip-requirements: requirements-1.6.txt
-            python-version: "3.9"
-          - pip-requirements: requirements-1.6.txt
-            python-version: "3.10"
-          - pip-requirements: requirements-1.6.txt
-            python-version: "3.11"
           - pip-requirements: requirements-1.7.txt
             python-version: "3.9"
           - pip-requirements: requirements-1.7.txt


### PR DESCRIPTION
## Summary
- drop dbt 1.6 and earlier from the GitHub Actions matrix

## Testing
- `make lint` *(fails: yamllint not found)*

------
https://chatgpt.com/codex/tasks/task_e_684658d382e0832c89c035a11af9e962